### PR TITLE
update gemspec license and authors

### DIFF
--- a/dropbox-api.gemspec
+++ b/dropbox-api.gemspec
@@ -5,12 +5,12 @@ require "dropbox-api/version"
 Gem::Specification.new do |s|
   s.name        = "dropbox-api"
   s.version     = Dropbox::API::VERSION
-  s.authors     = ["Marcin Bunsch"]
-  s.email       = ["marcin@futuresimple.com"]
+  s.authors     = ["Zendesk"]
+  s.email       = ["opensource@zendesk.com"]
   s.homepage    = "http://github.com/futuresimple/dropbox-api"
   s.summary     = "A Ruby client for the Dropbox REST API."
   s.description = "To deliver a more Rubyesque experience when using the Dropbox API."
-  s.license     = 'MIT'
+  s.license     = 'Apache License Version 2.0'
 
   s.rubyforge_project = "dropbox-api"
 

--- a/lib/dropbox-api/version.rb
+++ b/lib/dropbox-api/version.rb
@@ -1,5 +1,5 @@
 module Dropbox
   module API
-    VERSION = "0.4.7"
+    VERSION = "0.4.8"
   end
 end


### PR DESCRIPTION
update gemspec with updated license to Apache 2 and use company wide author and email Zendesk and opensource@zendesk.com. to release in rubygems patch version is bumped.